### PR TITLE
Update accompanist to 0.16.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-accompanist = "0.16.0"
+accompanist = "0.16.1"
 compose = "1.0.1"
 coroutines = "1.5.1"
 hilt = "2.38.1"


### PR DESCRIPTION
from 0.16.0.

Changelog:
https://github.com/google/accompanist/releases/tag/v0.16.1

The changes are for artifacts not being used by this project.