### PR TITLE
Fix bottom padding in Browser when IME visible

### DIFF
--- a/app/src/main/java/io/github/rsookram/srs/browser/Browser.kt
+++ b/app/src/main/java/io/github/rsookram/srs/browser/Browser.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.items
 import com.google.accompanist.insets.LocalWindowInsets
-import com.google.accompanist.insets.navigationBarsHeight
+import com.google.accompanist.insets.navigationBarsWithImePadding
 import com.google.accompanist.insets.rememberInsetsPaddingValues
 import io.github.rsookram.srs.BrowserCard
 import io.github.rsookram.srs.R
@@ -54,7 +54,7 @@ fun Browser(
                 onQueryChange
             )
         },
-        bottomBar = { Spacer(Modifier.navigationBarsHeight().fillMaxWidth()) },
+        bottomBar = { Spacer(Modifier.navigationBarsWithImePadding().fillMaxWidth()) },
     ) { contentPadding ->
         LazyColumn(
             contentPadding =

--- a/app/src/main/java/io/github/rsookram/srs/browser/Browser.kt
+++ b/app/src/main/java/io/github/rsookram/srs/browser/Browser.kt
@@ -37,7 +37,7 @@ import io.github.rsookram.srs.R
 
 @Composable
 fun Browser(
-    cardItems: LazyPagingItems<BrowserCard>,
+    cards: LazyPagingItems<BrowserCard>,
     query: String,
     onQueryChange: (String) -> Unit,
     onCardClick: (cardId: Long) -> Unit,
@@ -56,24 +56,17 @@ fun Browser(
         },
         bottomBar = { Spacer(Modifier.navigationBarsWithImePadding().fillMaxWidth()) },
     ) { contentPadding ->
-        LazyColumn(
+        Content(
             contentPadding =
                 rememberInsetsPaddingValues(
                     insets = LocalWindowInsets.current.navigationBars,
                     applyBottom = false,
                     additionalTop = contentPadding.calculateTopPadding(),
                     additionalBottom = contentPadding.calculateBottomPadding(),
-                )
-        ) {
-            items(cardItems) { item ->
-                val modifier = Modifier.heightIn(min = 48.dp)
-                if (item != null) {
-                    Card(modifier, item, onCardClick)
-                } else {
-                    Spacer(modifier)
-                }
-            }
-        }
+                ),
+            cards,
+            onCardClick,
+        )
     }
 }
 
@@ -104,12 +97,35 @@ private fun SearchField(
 }
 
 @Composable
-private fun Card(modifier: Modifier, card: BrowserCard, onClick: (cardId: Long) -> Unit) {
+private fun Content(
+    contentPadding: PaddingValues,
+    cards: LazyPagingItems<BrowserCard>,
+    onCardClick: (cardId: Long) -> Unit,
+) {
+    LazyColumn(contentPadding = contentPadding) {
+        items(cards) { item ->
+            val modifier = Modifier.heightIn(min = 48.dp)
+            if (item != null) {
+                Card(
+                    modifier,
+                    item.front,
+                    item.isLeech,
+                    onClick = { onCardClick(item.id) },
+                )
+            } else {
+                Spacer(modifier)
+            }
+        }
+    }
+}
+
+@Composable
+private fun Card(modifier: Modifier, label: String, isLeech: Boolean, onClick: () -> Unit) {
     Text(
-        card.front,
-        Modifier.clickable { onClick(card.id) }
+        label,
+        Modifier.clickable { onClick() }
             .background(
-                if (card.isLeech) {
+                if (isLeech) {
                     MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
                 } else {
                     Color.Transparent

--- a/app/src/main/java/io/github/rsookram/srs/browser/Browser.kt
+++ b/app/src/main/java/io/github/rsookram/srs/browser/Browser.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.items
@@ -34,6 +35,7 @@ import com.google.accompanist.insets.navigationBarsWithImePadding
 import com.google.accompanist.insets.rememberInsetsPaddingValues
 import io.github.rsookram.srs.BrowserCard
 import io.github.rsookram.srs.R
+import io.github.rsookram.srs.ui.theme.SrsTheme
 
 @Composable
 fun Browser(
@@ -96,6 +98,12 @@ private fun SearchField(
     }
 }
 
+@Preview
+@Composable
+private fun SearchFieldPreview() = SrsTheme {
+    SearchField(contentPadding = PaddingValues(), query = "", onQueryChange = {})
+}
+
 @Composable
 private fun Content(
     contentPadding: PaddingValues,
@@ -134,5 +142,27 @@ private fun Card(modifier: Modifier, label: String, isLeech: Boolean, onClick: (
             .fillMaxWidth()
             .then(modifier)
             .padding(16.dp)
+    )
+}
+
+@Preview
+@Composable
+private fun CardPreview() = SrsTheme {
+    Card(
+        Modifier.heightIn(min = 48.dp),
+        label = "card is not leech",
+        isLeech = false,
+        onClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun LeechCardPreview() = SrsTheme {
+    Card(
+        Modifier.heightIn(min = 48.dp),
+        label = "card is leech",
+        isLeech = true,
+        onClick = {},
     )
 }


### PR DESCRIPTION
Now it's possible to scroll to the bottom of the list while the IME is visible.

There are also new previews and some refactoring in this PR.