### PR TITLE
Fix back stack becoming empty after a review

### DIFF
--- a/app/src/main/java/io/github/rsookram/srs/review/ReviewViewModel.kt
+++ b/app/src/main/java/io/github/rsookram/srs/review/ReviewViewModel.kt
@@ -1,7 +1,7 @@
 package io.github.rsookram.srs.review
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -91,7 +91,7 @@ fun ReviewScreen(
 ) {
     val isFinished by vm.finishedReview.collectAsState(initial = false)
     if (isFinished) {
-        SideEffect { navController.popBackStack() }
+        LaunchedEffect(isFinished) { navController.popBackStack() }
         return
     }
 


### PR DESCRIPTION
The `SideEffect` was running multiple times after finishing all the
cards for review in a deck. This caused the back stack to be popped
until it was empty, and the result was a blank screen being shown.