### PR TITLE
Update Accompanist to 0.17.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-accompanist = "0.16.1"
+accompanist = "0.17.0"
 compose = "1.0.1"
 coroutines = "1.5.1"
 hilt = "2.38.1"


### PR DESCRIPTION
from 0.16.1.

The changes in this version don't affect any of the artifacts that this
project is using though.