### PR TITLE
Close dropdown menu when selecting edit

### DIFF
--- a/app/src/main/java/io/github/rsookram/srs/review/Review.kt
+++ b/app/src/main/java/io/github/rsookram/srs/review/Review.kt
@@ -76,9 +76,13 @@ fun Review(
                     val expanded = rememberSaveable { mutableStateOf(false) }
 
                     OverflowMenu(expanded) {
-                        DropdownMenuItem(onClick = onEditCardClick) {
-                            Text(stringResource(R.string.edit_card))
-                        }
+                        DropdownMenuItem(
+                            onClick = {
+                                expanded.value = false
+                                onEditCardClick()
+                            }
+                        ) { Text(stringResource(R.string.edit_card)) }
+
                         DropdownMenuItem(
                             onClick = {
                                 expanded.value = false


### PR DESCRIPTION
in the Review screen.

Before this, the dropdown menu would still be shown after returning to
this screen from the edit card screen.