### PR TITLE
Remove unneeded use of derivedStateOf

### DIFF
--- a/app/src/main/java/io/github/rsookram/srs/card/CardViewModel.kt
+++ b/app/src/main/java/io/github/rsookram/srs/card/CardViewModel.kt
@@ -3,7 +3,6 @@ package io.github.rsookram.srs.card
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -46,7 +45,8 @@ constructor(
     val decks: Flow<List<Deck>> = srs.getDecks()
 
     private var deck by mutableStateOf<Deck?>(null)
-    val selectedDeckName: String by derivedStateOf { deck?.name.orEmpty() }
+    val selectedDeckName: String
+        get() = deck?.name.orEmpty()
 
     var enableDeletion by mutableStateOf(false)
 


### PR DESCRIPTION
The code is more straightforward without it. `derivedStateOf` would be
more useful in cases where multiple states were being read and when the
value of the computation changed less frequently than the dependent
states, which isn't the case here.

Learned this from https://www.youtube.com/watch?v=eDcGrY_AVlw