### PR TITLE
Improve focus behaviour on new card screen

### DIFF
--- a/app/src/main/java/io/github/rsookram/srs/card/Card.kt
+++ b/app/src/main/java/io/github/rsookram/srs/card/Card.kt
@@ -52,18 +52,22 @@ import io.github.rsookram.srs.ui.ConfirmDeleteCardDialog
 import io.github.rsookram.srs.ui.OverflowMenu
 import io.github.rsookram.srs.ui.theme.SrsTheme
 
+data class CardState(
+    val front: String,
+    val onFrontChange: (String) -> Unit,
+    val back: String,
+    val onBackChange: (String) -> Unit,
+    val selectedDeckName: DeckName,
+    val onDeckClick: (Deck) -> Unit,
+)
+
 /**
  * Screen which allows the user to enter the content of a new card, or to edit the content of an
  * existing one.
  */
 @Composable
 fun Card(
-    front: String,
-    onFrontChange: (String) -> Unit,
-    back: String,
-    onBackChange: (String) -> Unit,
-    selectedDeckName: DeckName,
-    onDeckClick: (Deck) -> Unit,
+    cardState: CardState,
     decks: List<Deck>,
     onUpClick: () -> Unit,
     onConfirmClick: () -> Unit,
@@ -95,7 +99,12 @@ fun Card(
                     }
                 }
 
-                DeckDropdownMenu(Modifier.weight(1f), selectedDeckName, decks, onDeckClick)
+                DeckDropdownMenu(
+                    Modifier.weight(1f),
+                    cardState.selectedDeckName,
+                    decks,
+                    cardState.onDeckClick
+                )
 
                 if (enableDeletion) {
                     DeleteOverflowMenu(onDeleteClick = { showConfirmDeleteDialog = true })
@@ -128,8 +137,8 @@ fun Card(
                 )
         ) {
             OutlinedTextField(
-                value = front,
-                onValueChange = onFrontChange,
+                value = cardState.front,
+                onValueChange = cardState.onFrontChange,
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text(stringResource(R.string.front_side_of_card)) },
             )
@@ -137,8 +146,8 @@ fun Card(
             Spacer(Modifier.height(16.dp))
 
             OutlinedTextField(
-                value = back,
-                onValueChange = onBackChange,
+                value = cardState.back,
+                onValueChange = cardState.onBackChange,
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text(stringResource(R.string.back_side_of_card)) },
             )
@@ -163,14 +172,16 @@ private fun CardPreview() = SrsTheme {
         )
 
     Card(
-        front = "",
-        onFrontChange = {},
-        back = "",
-        onBackChange = {},
-        selectedDeckName = decks.first().name,
+        CardState(
+            front = "",
+            onFrontChange = {},
+            back = "",
+            onBackChange = {},
+            selectedDeckName = decks.first().name,
+            onDeckClick = {},
+        ),
         decks = decks,
         onUpClick = {},
-        onDeckClick = {},
         onConfirmClick = {},
         enableDeletion = false,
         onDeleteCardClick = {},

--- a/app/src/main/java/io/github/rsookram/srs/card/Card.kt
+++ b/app/src/main/java/io/github/rsookram/srs/card/Card.kt
@@ -38,6 +38,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -52,13 +54,14 @@ import io.github.rsookram.srs.ui.ConfirmDeleteCardDialog
 import io.github.rsookram.srs.ui.OverflowMenu
 import io.github.rsookram.srs.ui.theme.SrsTheme
 
-data class CardState(
+class CardState(
     val front: String,
     val onFrontChange: (String) -> Unit,
     val back: String,
     val onBackChange: (String) -> Unit,
     val selectedDeckName: DeckName,
     val onDeckClick: (Deck) -> Unit,
+    val frontFocusRequester: FocusRequester,
 )
 
 /**
@@ -139,7 +142,7 @@ fun Card(
             OutlinedTextField(
                 value = cardState.front,
                 onValueChange = cardState.onFrontChange,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().focusRequester(cardState.frontFocusRequester),
                 label = { Text(stringResource(R.string.front_side_of_card)) },
             )
 
@@ -179,6 +182,7 @@ private fun CardPreview() = SrsTheme {
             onBackChange = {},
             selectedDeckName = decks.first().name,
             onDeckClick = {},
+            frontFocusRequester = FocusRequester(),
         ),
         decks = decks,
         onUpClick = {},

--- a/app/src/main/java/io/github/rsookram/srs/card/CardViewModel.kt
+++ b/app/src/main/java/io/github/rsookram/srs/card/CardViewModel.kt
@@ -145,13 +145,18 @@ constructor(
 fun CardScreen(navController: NavController, vm: CardViewModel = hiltViewModel()) {
     LaunchedEffect(vm.upNavigations) { vm.upNavigations.collect { navController.popBackStack() } }
 
+    val cardState =
+        CardState(
+            front = vm.front,
+            onFrontChange = vm::onFrontChange,
+            back = vm.back,
+            onBackChange = vm::onBackChange,
+            selectedDeckName = vm.selectedDeckName,
+            onDeckClick = vm::onDeckClick,
+        )
+
     Card(
-        front = vm.front,
-        onFrontChange = vm::onFrontChange,
-        back = vm.back,
-        onBackChange = vm::onBackChange,
-        selectedDeckName = vm.selectedDeckName,
-        onDeckClick = vm::onDeckClick,
+        cardState,
         decks = vm.decks.collectAsState(emptyList()).value,
         onUpClick = vm::onUpClick,
         onConfirmClick = vm::onConfirmClick,


### PR DESCRIPTION
When creating a new card, the focus now starts on the front field, and
the soft keyboard is shown automatically, saving one click.

The focus also gets reset to the front field after creating a new card,
so that it's easier to start making the next one.