### PR TITLE
Reduce coroutine impact on APK size

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,8 @@ android {
     packagingOptions.resources {
         excludes += setOf(
             "kotlin/**",
+            "**/DebugProbesKt.bin",
+
             "META-INF/*.version",
         )
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,9 @@
 -keepclassmembers enum * {
     public static **[] values();
 }
+
+# https://issuetracker.google.com/issues/155947700
+-assumenosideeffects public class kotlin.coroutines.jvm.internal.BaseContinuationImpl {
+    public java.lang.StackTraceElement getStackTraceElement() return null;
+}
+-checkdiscard class kotlin.coroutines.jvm.internal.DebugMetadata


### PR DESCRIPTION
This reduces APK size by ~38.8 KB (~2%).

## Diffuse

```
          │           compressed            │          uncompressed           
          ├──────────┬──────────┬───────────┼──────────┬──────────┬───────────
 APK      │ old      │ new      │ diff      │ old      │ new      │ diff      
──────────┼──────────┼──────────┼───────────┼──────────┼──────────┼───────────
      dex │  1.7 MiB │  1.7 MiB │ -37.9 KiB │  1.7 MiB │  1.7 MiB │ -37.9 KiB 
     arsc │ 18.9 KiB │ 18.9 KiB │       0 B │ 18.8 KiB │ 18.8 KiB │       0 B 
 manifest │  1.4 KiB │  1.4 KiB │       0 B │  3.9 KiB │  3.9 KiB │       0 B 
      res │  6.1 KiB │  6.1 KiB │       0 B │ 10.6 KiB │ 10.6 KiB │       0 B 
    asset │  5.2 KiB │  5.2 KiB │     -19 B │    5 KiB │    5 KiB │     -19 B 
    other │  1.6 KiB │    772 B │    -883 B │  1.8 KiB │    161 B │  -1.7 KiB 
──────────┼──────────┼──────────┼───────────┼──────────┼──────────┼───────────
    total │  1.8 MiB │  1.7 MiB │ -38.8 KiB │  1.8 MiB │  1.7 MiB │ -39.6 KiB 


 DEX     │ old   │ new   │ diff               
─────────┼───────┼───────┼────────────────────
   files │     1 │     1 │    0               
 strings │  7862 │  7436 │ -426 (+71 -497)    
   types │  3075 │  3072 │   -3 (+70 -73)     
 classes │  2573 │  2571 │   -2 (+0 -2)       
 methods │ 12345 │ 12334 │  -11 (+7826 -7837) 
  fields │  8098 │  8096 │   -2 (+5599 -5601)
```